### PR TITLE
Generate ASCII banner dynamically

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,8 @@
+fixtures:
+  repositories:
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    concat: "git://github.com/puppetlabs/puppetlabs-concat.git"
+    pe_gem: "git://github.com/puppetlabs/puppetlabs-pe_gem.git"
+  symlinks:
+    motd: "#{source_dir}"
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.*.sw?
+pkg
+spec/fixtures
+.rspec_system
+.vagrant
+log
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: ruby
+bundler_args: --without development
+before_install: rm Gemfile.lock || true
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.3
+script: bundle exec rake spec
+env:
+  - PUPPET_VERSION="~> 3.1.0"
+  - PUPPET_VERSION="~> 3.2.0"
+  - PUPPET_VERSION="~> 3.3.0"
+  - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.7.3"
+  - PUPPET_VERSION="~> 3.7.3" FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 3.7.3" STRINGIFY_FACTS=no
+  - PUPPET_VERSION="~> 3.7.3" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.7.3" ORDERING=random
+matrix:
+  exclude:
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 3.1.0"
+  - rvm: 2.1.3
+    env: PUPPET_VERSION="~> 3.1.0"
+  - rvm: 2.1.3
+    env: PUPPET_VERSION="~> 3.2.0"
+  - rvm: 2.1.3
+    env: PUPPET_VERSION="~> 3.3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,24 @@
+source "https://rubygems.org"
+
+group :test do
+  gem "rake"
+  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.3'
+  gem "puppet-lint"
+  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "rspec", '< 3.0.0'
+  gem "puppet-syntax"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "puppet_spec_facts", '>= 0.2.1'
+  gem "artii"
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "beaker"
+  gem "beaker-rspec"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,45 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+# These two gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
+
+PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.fail_on_warnings = false
+
+# Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
+# http://puppet-lint.com/checks/class_parameter_defaults/
+PuppetLint.configuration.send('disable_class_parameter_defaults')
+# http://puppet-lint.com/checks/class_inherits_from_params_class/
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths = exclude_paths
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,58 @@
+{
+  "name": "ploperations-motd",
+  "version": "0.1.0",
+  "source": "https://github.com/puppetlabs-operations/puppet-motd",
+  "author": "Puppet Labs Operations",
+  "license": "Apache-2.0",
+  "summary": "Manage MOTD file",
+  "description": "Generate a useful MOTD with an attractive banner",
+  "project_page": "https://github.com/puppetlabs-operations/puppet-motd",
+  "dependencies": [
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 1.0.0 <2.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": "3.x"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ]
+}

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,1 @@
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/classes/motd_spec.rb
+++ b/spec/classes/motd_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+shared_examples_for "all motd cases" do
+  it {
+    should compile.with_all_deps
+    should contain_concat('/etc/motd')
+    should contain_file('/etc/motd')
+    should contain_class('Motd')
+    should contain_file('/etc/banner')
+    should contain_file('/fake_concat_basedir/_etc_motd/fragments/02_motd_header').with_content(/fact3/)
+  }
+end
+
+PuppetSpecFacts.facts_for_platform_by_name(["Debian_wheezy_7.7_amd64_3.7.2_structured", "Ubuntu_precise_12.04_amd64_PE-3.3.2_stringified", "Ubuntu_trusty_14.04_amd64_PE-3.3.2_stringified", "CentOS_5.11_x86_64_PE-3.3.2_stringified"]).each do |name, facthash|
+  describe "motd", :type => :class do
+    let(:facts) { facthash }
+    facthash['is_pe'] = (facthash['puppetversion'].include?('Enterprise')) ? true : false
+
+    context "running on #{name}" do
+      context "ascii_art enabled" do
+        ['graffiti','whimsy','usaflag'].each do |font|
+          context "ascii_art_font => #{font}" do
+            let(:params) {{
+              :enable_ascii_art => 'true',
+              :ascii_art_text   => 'Hello, rspec',
+              :ascii_art_font   => font,
+              :fact_list        => ['fact1', 'fact2', 'fact3'],
+            }}
+
+
+            it_behaves_like "all motd cases"
+              gem_provider = facthash['is_pe'] ? 'pe_gem' : "gem"
+              it { should contain_package('artii').with(
+                'provider' => gem_provider,
+              ) }
+          end
+        end
+      end
+
+      context "ascii_art disabled" do
+        let(:params) {{
+          :enable_ascii_art => 'false',
+          :fact_list        => ['fact1','fact2','fact3'],
+        }}
+
+        it_behaves_like "all motd cases"
+        it { should_not contain_package('artii') }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'puppet_spec_facts'
+include PuppetSpecFacts
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -1,11 +1,8 @@
-__________                            __    .____          ___.
-\______   \__ ________ ______   _____/  |_  |    |   _____ \_ |__   ______
- |     ___/  |  \____ \\____ \_/ __ \   __\ |    |   \__  \ | __ \ /  ___/
- |    |   |  |  /  |_> >  |_> >  ___/|  |   |    |___ / __ \| \_\ \\___ \
- |____|   |____/|   __/|   __/ \___  >__|   |_______ (____  /___  /____  >
-                |__|   |__|        \/               \/    \/    \/     \/
+<% if @enable_ascii_art!= false then -%>
+<%= begin; require 'artii'; a = Artii::Base.new :font => @ascii_art_font; a.asciify(@ascii_art_text); rescue LoadError; "artii gem not installed on puppetmaster; cannot generate ascii art"; end %>
+<% end -%>
 
-(<%= @fqdn %>) : (<%= @ipaddress %>) : (<%= @whereami %>)
+<%= @fact_list.map {|a| "(#{a})"}.join(' : ') %>
 <%= @operatingsystem %> <%= @operatingsystemrelease %><% if has_variable?('lsbdistcodename') then %>/<%= @lsbdistcodename %><% end %> <%= @architecture %>
 <% if has_variable?('processor0') then -%>Processor: <%= @processor0.gsub( / +/ , ' ' ) -%> <% end -%> <% if has_variable?('memorysize') then -%> Memory: <%= @memorysize -%> <% end %>
 

--- a/tests/motd-banner.pp
+++ b/tests/motd-banner.pp
@@ -1,0 +1,4 @@
+class {'motd':
+  banner    => 'PuppetLabs',
+  motd_file => '/tmp/motd',
+}


### PR DESCRIPTION
Use the artii ruby gem to generate the banner automatically.

Without this change, the module is limited to being puppetlabs-ops-only.

The change allows the module to be published by making it flexible enough to be plausibly useful outside of Puppet Labs.
